### PR TITLE
Add permission on admin routes

### DIFF
--- a/src/Resources/config/routing/admin.yaml
+++ b/src/Resources/config/routing/admin.yaml
@@ -2,6 +2,7 @@ monsieurbiz_shipping_slot_admin_config:
     resource: |
         alias: monsieurbiz_shipping_slot.shipping_slot_config
         section: admin
+        permission: true
         templates: "@SyliusAdmin\\Crud"
         except: ['show']
         redirect: update
@@ -17,6 +18,7 @@ monsieurbiz_shipping_slot_admin_slot:
     resource: |
         alias: monsieurbiz_shipping_slot.slot
         section: admin
+        permission: true
         templates: "@SyliusAdmin\\Crud"
         except: ['show']
         redirect: update


### PR DESCRIPTION
Add `permission: true` on routes so in case there is SyliusPlus and the RBAC plugin these routes can be checked for permissions.
This change has no effect on a standard sylius.